### PR TITLE
fix comment and style for quality range checking

### DIFF
--- a/adafruit_ov5640/__init__.py
+++ b/adafruit_ov5640/__init__.py
@@ -1487,14 +1487,14 @@ class OV5640(_SCCB16CameraBase):  # pylint: disable=too-many-instance-attributes
 
     @property
     def quality(self) -> int:
-        """Controls the JPEG quality.  Valid range is from 2..55 inclusive"""
+        """Controls the JPEG quality.  Valid range is from 2..54 inclusive"""
         return self._read_register(_COMPRESSION_CTRL07) & 0x3F
 
     @quality.setter
     def quality(self, value: int) -> None:
-        if not 2 <= value < 55:
+        if not 2 <= value <= 54:
             raise ValueError(
-                f"Invalid quality value {value}, use a value from 2..55 inclusive"
+                f"Invalid quality value {value}, use a value from 2..54 inclusive"
             )
         self._write_register(_COMPRESSION_CTRL07, value & 0x3F)
 


### PR DESCRIPTION
Fix comment, error message and code style for quality range checking to be accurate and match earlier styles.

Comments on lines: 1490, 1497 use range verbiage such as:
        """Controls the JPEG quality.  Valid range is from 2..55 inclusive"""
However, 55 is not included.  
Also, the check on 1495 uses the following checking style using '<':
`        if not 2 <= value < 55:`
However, earlier range checking for saturation use "<=" on the upper comparison, i.e.
`       if not -4 <= value <= 4:`
Which is more consistent with the comment and error message.
Changes:
* Update the comments and error messages to be "2..54 inclusive"
* Update the code to match the range checking style of the saturation getter/setter by using <= 54 on the upper limit.

I did not test these changes.  If you can point me instructions on how to build a firmware image with this change, I'd be happy to.